### PR TITLE
Include JavaScript i18n in workbench pages

### DIFF
--- a/workbench/templates/workbench/block.html
+++ b/workbench/templates/workbench/block.html
@@ -3,6 +3,7 @@
     <head>
         <link rel="stylesheet" type="text/css"
               href="{% static 'workbench/css/workbench.css' %}">
+        <script type="text/javascript" src="{% url django.views.i18n.javascript_catalog %}"></script>
         <script>
             // TODO: This should be handled more modularly.
             studentId = '{{student_id}}';

--- a/workbench/templates/workbench/blockview.html
+++ b/workbench/templates/workbench/blockview.html
@@ -5,6 +5,7 @@
             student_id = '{{student_id}}';
             handlerBaseUrl = '{% url workbench_index %}handler/';
         </script>
+        <script type="text/javascript" src="{% url django.views.i18n.javascript_catalog %}"></script>
         {{head_html|safe}}
     </head>
     <body class="view-workbench">

--- a/workbench/urls.py
+++ b/workbench/urls.py
@@ -58,3 +58,8 @@ urlpatterns = patterns(
 )
 
 urlpatterns += staticfiles_urlpatterns()
+
+# JavaScript i18n
+urlpatterns += patterns('',
+    (r'^i18n.js$', 'django.views.i18n.javascript_catalog', {'packages': tuple()}),
+)


### PR DESCRIPTION
In order to use the `gettext()` function provided by Django's `jsi18n` view, we need to include it on the page.  This includes the `jsi18n` script by default in workbench, so XBlock-specific JavaScript can use `gettext()`. 

@sarina 
