### PR TITLE
Fix storage of preference scoped XBlock fields

### DIFF
--- a/sample_xblocks/basic/content.py
+++ b/sample_xblocks/basic/content.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Content-oriented XBlocks."""
 
 from string import Template  # pylint: disable=W0402
@@ -10,9 +11,136 @@ from xblock.fragment import Fragment
 
 class HelloWorldBlock(XBlock):
     """A simple block: just show some fixed content."""
+
     def fallback_view(self, view_name, context=None):  # pylint: disable=W0613
         """Provide a fallback view handler"""
-        return Fragment(u"Hello, world!")
+        return Fragment(u"Hello, World!")
+
+    @staticmethod
+    def workbench_scenarios():
+        return [
+            ("Hello World", "<helloworld_demo/>")
+        ]
+
+
+class AllScopesBlock(XBlock):
+    """Block that has a string field for every scope.
+
+    Help strings are cribbed from the XBlock repo.
+    """
+    content_field = String(
+        scope=Scope.content,
+        default=u"This is content!",
+        help=(
+            u"The content scope is used to save data for all users, for one "
+            u"particular block, across all runs of a course. An example might "
+            u"be an XBlock that wishes to tabulate user \"upvotes\", or HTML "
+            u"content to display literally on the page (this example being the "
+            u"reason this scope is named `content`)."
+        )
+    )
+    settings_field = String(
+        scope=Scope.settings,
+        default=u"This is settings!",
+        help=(
+            u"The settings scope is used to save data for all users, for one "
+            u"particular block, for one specific run of a course. This is like "
+            u"the `content` scope, but scoped to one run of a course. An "
+            u"example might be a due date for a problem."
+        )
+    )
+    user_state_field = String(
+        scope=Scope.user_state,
+        default=u"This is user_state!",
+        help=(
+            u"The user_state scope is used to save data for one user, for one "
+            u"block, for one run of a course. An example might be how many "
+            u"points a user scored on one specific problem."
+        )
+    )
+    preferences_field = String(
+        scope=Scope.preferences,
+        default=u"This is preferences!",
+        help=(
+            u"The preferences scope is used to save data for one user, for all "
+            u"instances of one specific TYPE of block, across the entire "
+            u"platform. An example might be that a user can set their preferred "
+            u"default speed for the video player. This default would apply to "
+            u"all instances of the video player, across the whole platform, but "
+            u"only for that student."
+        )
+    )
+    user_info_field = String(
+        scope=Scope.user_info,
+        default=u"This is user_info!",
+        help=(
+            u"The user_info scope is used to save data for one user, across "
+            u"the entire platform. An example might be a user's time zone or "
+            u"language preference."
+        )
+    )
+    user_state_summary_field = String(
+        scope=Scope.user_state_summary,
+        default=u"This is user_state_summary!",
+        help=(
+            u"The user_state_summary scope is used to save data aggregated "
+            u"across many users of a single block. For example, a block might "
+            u"store a histogram of the points scored by all users attempting a "
+            u"problem. For the purposes of the workbench, this is stored in "
+            u"the same JSON record as settings_field."
+        )
+    )
+
+    def fallback_view(self, view_name, context=None):  # pylint: disable=W0613
+        """Display all fields, their values, and some helpful info text."""
+        entry_template = u"""
+            <tr>
+                <td>{field_name}</td>
+                <td>{value}</td>
+                <td>{help}</td>
+            </tr>
+        """
+        # Go through all the named fields declared for this block, but exclude
+        # things that users can't directly manipulate by editing state in the
+        # database (name, parent, tags).
+        entries = [
+            entry_template.format(
+                field_name=field_name,
+                value=getattr(self, field_name),
+                help=field.help
+            )
+            for field_name, field in self.fields.items()
+            if field_name not in ["name", "parent", "tags"]
+        ]
+
+        frag = Fragment(
+            u"""
+                <table style="vertical-align:top;">
+                    <tr>
+                        <th>Name</th>
+                        <th>Value</th>
+                        <th>About</th>
+                    </tr>
+                    {}
+                </table>
+
+            """.format(u"\n".join(entries))
+        )
+        frag.add_css("""
+            table { border-collapse:collapse; }
+            table, th, td { border: 1px solid black; }
+            td { vertical-align:top; }
+            """
+        )
+
+        return frag
+
+    @staticmethod
+    def workbench_scenarios():
+        """Return very basic display of fields and help."""
+        return [
+            ("All Scopes", "<allscopes_demo/>")
+        ]
 
 
 class HtmlBlock(XBlock):

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(
         'xblock.v1': [
             # Basic XBlocks
             'helloworld_demo = sample_xblocks.basic.content:HelloWorldBlock',
+            'allscopes_demo = sample_xblocks.basic.content:AllScopesBlock',
             'html_demo = sample_xblocks.basic.content:HtmlBlock',
             'sequence_demo = sample_xblocks.basic.structure:Sequence',
             'vertical_demo = sample_xblocks.basic.structure:VerticalBlock',

--- a/workbench/models.py
+++ b/workbench/models.py
@@ -78,8 +78,22 @@ class XBlockState(models.Model):
         block_scope_name = shorten_scope_name(block_scope_full_name)
         scope_id = key.block_scope_id
 
-        # Ask our ID Manager for how this scope_id maps to scenario and XML tag
-        scenario, tag, _ = scope_id.split(".", 2)
+        # A block_scope_name of "type" is special -- this means that it's a
+        # preferences scoped var that is global to the XBlock class (and not to
+        # any particular scenario, definition, or usage). As such, it doesn't
+        # abide by the {scenario}.{tag}.{def}.{usage} convention as our other
+        # keys do, and is always simply {tag}
+        #
+        # A block_scope_name of "all" means user_info -- data that is
+        # specific to a user, but crosses all scenarios and blocks (e.g.
+        # user timezone, language). In this case, we also set our scenario to
+        # be None.
+        if block_scope_name in ["type", "all"]:
+            scenario = None
+            tag = scope_id
+        else:
+            scenario, tag, _ = scope_id.split(".", 2)
+
         record, _ = cls.objects.get_or_create(
             scope=block_scope_name,
             scope_id=key.block_scope_id,


### PR DESCRIPTION
This explicitly handles the preferences scope in the model key lookup. It also adds a preference scoped field to the HelloWorldBlock. Since we cycle through all scenarios to make sure they don't cause load errors in our tests, this should catch the problem in the future. This addresses issue #7 

@singingwolfboy, @nedbat, @terman 
