### PR TITLE
Will/fix multiple objects returned

### DIFF
--- a/workbench/admin.py
+++ b/workbench/admin.py
@@ -14,9 +14,9 @@ class XBlockStateAdmin(admin.ModelAdmin):
     categories. Since things like `tag` and `scenario` are set on write, weird
     things could happen if you muck with them later on.
     """
-    list_display = ['scope_id', 'scope', 'user_id', 'state']
+    list_display = ['scope_id', 'scope', 'user_id', 'field', 'value']
     list_filter = ['scope', 'user_id', 'scenario', 'tag']
-    search_fields = ['user_id', 'scope_id', 'state']
+    search_fields = ['user_id', 'scope_id', 'field']
     readonly_fields = [
         'scope', 'scope_id', 'scenario', 'tag', 'user_id', 'created'
     ]

--- a/workbench/test/test_models.py
+++ b/workbench/test/test_models.py
@@ -1,0 +1,28 @@
+"""
+Tests for workbench models.
+"""
+
+from django.test import TestCase
+from xblock.fields import Scope
+from xblock.runtime import KeyValueStore
+from workbench.models import XBlockState
+
+
+class XBlockStateTest(TestCase):
+    """Tests for XBlock persistent state storage."""
+
+    def test_parallel_writes(self):
+        # Simulate what happens when multiple processes
+        # update a field in parallel.
+        key = KeyValueStore.Key(
+            scope=Scope.parent,
+            user_id="test student",
+            block_scope_id="scenario.type.def",
+            field_name="test field"
+        )
+        XBlockState.create_for_key(key)
+        second = XBlockState.create_for_key(key)
+
+        # Check that we get back the most recent state
+        retrieved = XBlockState.get_for_key(key)
+        self.assertEqual(retrieved.pk, second.pk)


### PR DESCRIPTION
In order to more easily test concurrency issues in ORA2, I've been running workbench with gunicorn and MySQL in repeatable-read mode.  Unfortunately, this sometimes causes 500 errors when the workbench persistence layer tries to `get_or_create` an `XBlockState` model in the database.  If this method is called in parallel with the database isolation set to repeatable read, each caller will see that no model exists, so they will all try to create one.  The end result is that multiple `XBlockState`s exist for the same key, causing the `get_or_create` to raise a `MultipleObjectsReturned` exception.

I've attempted to solve this by:
1) Separating the `get_or_create` call into separate steps, and calling `create` only when setting a field.
2) Redefining `XBlockState` to represent a particular key field and adding a `modified` timestamp.
3) Updating the "get" call to return the `XBlockState` with the most recent `modified` timestamp.

@nedbat and @ormsbee please review.
