### PR TITLE
Adds support for passing JSON parameters to initialize XBlock

### DIFF
--- a/workbench/runtime.py
+++ b/workbench/runtime.py
@@ -209,11 +209,23 @@ class WorkbenchRuntime(Runtime):
         if block.name:
             data['name'] = block.name
 
-        html = u"<div class='xblock'%s>%s</div>" % (
-            "".join(" data-%s='%s'" % item for item in data.items()),
-            frag.body_html(),
-        )
+        json_init = ""
+        # TODO/Note: We eventually want to remove: hasattr(frag, 'json_init_args')
+        # However, I'd like to maintain backwards-compatibility with older XBlock 
+        # for at least a little while so as not to adversely effect developers. 
+        # pmitros/Jun 28, 2014. 
+        if hasattr(frag, 'json_init_args') and frag.json_init_args is not None: 
+            json_init = u'<script type="json/xblock-args" class="xblock_json_init_args">' + \
+                u'{data}</script>'.format(data=json.dumps(frag.json_init_args))
+
+        html = u"<div class='xblock'{properties}>{body}{js}</div>".format(
+            properties="".join(" data-%s='%s'" % item for item in data.items() ),
+            body=frag.body_html(),
+            js=json_init
+            )
+
         wrapped.add_content(html)
+        
         wrapped.add_frag_resources(frag)
         return wrapped
 

--- a/workbench/static/workbench/js/runtime/1.js
+++ b/workbench/static/workbench/js/runtime/1.js
@@ -58,7 +58,14 @@ var XBlock = (function () {
 
         var runtime = RuntimeProvider.getRuntime(version);
         var initFn = window[$(element).data('init')];
-        var jsBlock = initFn(runtime, element) || {};
+        var jsBlock;
+        if(initFn.length == 2) {
+            jsBlock = initFn(runtime, element) || {};
+        } else if (initFn.length == 3) {
+            data = JSON.parse($(".xblock_json_init_args", element).text());
+            jsBlock = initFn(runtime, element, data) || {};
+        }
+            
         jsBlock.element = element;
         jsBlock.name = $(element).data('name');
         return jsBlock;


### PR DESCRIPTION
This allows this XBlock initialization to pass a JSON argument from Python to JavaScript. This eliminates lots of template hacks getting data into XBlocks. 

There is a matching commit in the XBlock repo. 

@cpennington @rocha 
