### PR TITLE
Use Makefile to install requirements and run tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: python
 python:
-  - "2.7"
+    - "2.7"
 before_install:
-  - "export DISPLAY=:99"
-  - "sh -e /etc/init.d/xvfb start"
-install: pip install -r requirements.txt
-script:  python manage.py test
+    - "export DISPLAY=:99"
+    - "sh -e /etc/init.d/xvfb start"
+install:
+    - "make install"
+script:
+    - "make test"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+all: install test
+
+install:
+	# TODO: we need to install requirements.txt so XBlock is installed
+	# from a GitHub repo.  Once XBlock is available through PyPi,
+	# we can install all requirements using setup.py
+	pip install -r requirements.txt
+	pip install -e .
+	pip install -r test-requirements.txt
+
+test:
+	python manage.py test

--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ supported by edX.
 3.  Install the requirements and register the XBlock entry points with (you may
     need to sudo this if you don't use virtualenv):
 
-        $ pip install -r requirements.txt
+        $ make install
 
 4. Create and sync the sqllite DB
 
@@ -39,9 +39,9 @@ supported by edX.
 Testing
 --------
 
-To run the test suite:
+To install all requirements and run the test suite:
 
-    $ python manage.py test
+    $ make
 
 This will run:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,14 @@
+cookiecutter==0.7.1
+Django >= 1.4, < 1.5
+lxml
+requests
+webob
+simplejson
+lazy
+
 # XBlock
+# TODO: upload XBlock to PyPi so we can include it in the setup.py requirements
 -e git+https://github.com/edx/XBlock.git@3b6e4218bd326f84dbeb0baed7b2b7813ffea3dd#egg=XBlock
 
-#acid xblock
+# Acid xblock
 -e git+https://github.com/edx/acid-block.git@459aff7b63db8f2c5decd1755706c1a64fb4ebb1#egg=acid-xblock
-
-# install this locally
--e .
-
-cookiecutter==0.7.1

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,39 @@ def find_package_data(pkg, data_paths):
                 data.append(os.path.relpath(os.path.join(dirname, fname), package_dir))
     return {pkg: data}
 
+
+def is_requirement(line):
+    """
+    Return True if the requirement line is a package requirement;
+    that is, it is not blank, a comment, or editable.
+    """
+    # Remove whitespace at the start/end of the line
+    line = line.strip()
+
+    # Skip blank lines, comments, and editable installs
+    return not (
+        line == '' or
+        line.startswith('-r') or
+        line.startswith('#') or
+        line.startswith('-e') or
+        line.startswith('git+')
+    )
+
+
+def load_requirements(*requirements_paths):
+    """
+    Load all requirements from the specified requirements files.
+    Returns a list of requirement strings.
+    """
+    requirements = set()
+    for path in requirements_paths:
+        requirements.update(
+            line.strip() for line in open(path).readlines()
+            if is_requirement(line)
+        )
+    return list(requirements)
+
+
 package_data = {}
 package_data.update(find_package_data("sample_xblocks.basic", ["public", "templates"]))
 package_data.update(find_package_data("sample_xblocks.thumbs", ["static"]))
@@ -29,23 +62,8 @@ setup(
         'sample_xblocks.thumbs',
         'workbench',
     ],
-    install_requires=[
-        # 'XBlock',  # Can put this once XBlock is on PyPI
-        'Django >= 1.4, < 1.5',
-        'lxml',
-        'requests',
-        'webob',
-        'simplejson',
-        'lazy',
-        'django_nose',
-        'mock',
-        'coverage',
-        'pylint == 0.28',
-        'selenium',
-        'rednose',
-        'pep8',
-        'diff-cover >= 0.2.1',
-    ],
+    install_requires=load_requirements('requirements.txt'),
+    tests_require=load_requirements('test-requirements.txt'),
     entry_points={
         'xblock.v1': [
             # Basic XBlocks

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,8 @@
+coverage
+diff-cover >= 0.2.1
+django_nose
+mock
+pylint==0.28
+pep8
+rednose
+selenium


### PR DESCRIPTION
- Add a Makefile for installing requirements and running tests.  The new commands are:

```
# Installs Python requirements
make install

# Runs the test suite
make test

# Install and run the tests
make
```
- Separate the test requirements from the base requirements.  When installing using `setup.py`, the test requirements will no longer be installed by default.  This is helpful for projects like ORA2, which need to use the XBlock SDK but aren't using requirements like Selenium.

@nedbat please review.
