### PR TITLE
Make Makefile executable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+#!/usr/bin/make -f
+
 SQLITE_DB=workbench.db
 
 all: install test


### PR DESCRIPTION
There isn't a burning need for this; it's more of a "best practices" sort of thing, which allows the project to be made by directly invoking `./Makefile`.
