### PR TITLE
Add Makefile target to create SQLite DB

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,18 @@
+SQLITE_DB=workbench.db
+
 all: install test
 
-install:
+.PHONY: install
+install: $(SQLITE_DB)
 	# TODO: we need to install requirements.txt so XBlock is installed
 	# from a GitHub repo.  Once XBlock is available through PyPi,
 	# we can install all requirements using setup.py
 	pip install -r requirements.txt
 	pip install -e .
 	pip install -r test-requirements.txt
+
+$(SQLITE_DB):
+	python manage.py syncdb
 
 test:
 	python manage.py test

--- a/README.rst
+++ b/README.rst
@@ -24,10 +24,6 @@ supported by edX.
 
         $ make install
 
-4. Create and sync the sqllite DB
-
-        $ python manage.py syncdb
-
 4.  Run the Django development server:
 
         $ python manage.py runserver


### PR DESCRIPTION
The `workbench.db` target is a prerequisite of the `install` target.
