### PR TITLE
Make SQLiteDB target after requirements installed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,10 @@ SQLITE_DB=workbench.db
 all: install test
 
 .PHONY: install
-install: $(SQLITE_DB)
+install: pip $(SQLITE_DB)
+
+.PHONY: pip
+pip:
 	# TODO: we need to install requirements.txt so XBlock is installed
 	# from a GitHub repo.  Once XBlock is available through PyPi,
 	# we can install all requirements using setup.py
@@ -14,7 +17,8 @@ install: $(SQLITE_DB)
 	pip install -r test-requirements.txt
 
 $(SQLITE_DB):
-	python manage.py syncdb
+	# The --noinput flag is for non-interactive runs, e.g. TravisCI.
+	python manage.py syncdb --noinput
 
 test:
 	python manage.py test


### PR DESCRIPTION
I introduced a bug [0][1] which caused `make install` to fail on fresh
installs. This happened because the `DB` target was a prerequisite of
the `install` target, which meant `DB` was trying to reference
requirements, i.e. Django, before they had been installed.

This removes the prerequisite and allows the installation to complete as
intended.

Reported-By: @nedbat

[0] fc044609e2c048b19f37f5086c8cd8a69333ead2
[1] https://github.com/edx/xblock-sdk/pull/28#issuecomment-53821041
