### PR TITLE
Added missing dependency: certifi

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+certifi
 cookiecutter==0.7.1
 Django >= 1.4, < 1.5
 lxml


### PR DESCRIPTION
At least under Python 2.7.5 on OSX 10.9.4, the certifi module is not installed by default, but Django produces a crash page when attempting to access the workbench without it. 
