### PR TITLE
Implemented error handling for failed xblocks

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,11 +8,11 @@ lazy
 
 # XBlock
 # This is not in/from PyPi, since it moves fast
--e git+https://github.com/edx/XBlock.git@23dd705cd3f527311701d848f5a1425be23edc33#egg=XBlock
+-e git+https://github.com/edx/XBlock.git#egg=XBlock
 
 # Acid xblock
--e git+https://github.com/edx/acid-block.git@459aff7b63db8f2c5decd1755706c1a64fb4ebb1#egg=acid-xblock
+-e git+https://github.com/edx/acid-block.git#egg=acid-xblock
 
 fs
 pypng
--e git+https://github.com/pmitros/django-pyfs.git@514607d78535fd80bfd23184cd292ee5799b500d#egg=djpyfs
+-e git+https://github.com/pmitros/django-pyfs.git#egg=djpyfs

--- a/workbench/scenarios.py
+++ b/workbench/scenarios.py
@@ -3,6 +3,7 @@
 This code is in the Workbench layer.
 
 """
+import traceback
 from collections import namedtuple
 
 from django.conf import settings
@@ -36,7 +37,8 @@ def add_xml_scenario(scname, description, xml):
     except Exception as exc:
         FAILURES.append({
             "name": scname,
-            "exception": exc
+            "exc": exc,
+            "tb": traceback.format_exc(exc)
         })
 
 
@@ -74,4 +76,8 @@ def init_scenarios():
         add_class_scenarios(class_name, cls)
 
     for failure in XBlock.failed_classes():
-        FAILURES.append(failure)
+        FAILURES.append({
+            "name": failure["name"],
+            "exc": failure["exception"],
+            "tb": traceback.format_exc(failure["exception"])
+        })

--- a/workbench/templates/workbench/index.html
+++ b/workbench/templates/workbench/index.html
@@ -17,16 +17,13 @@
                     {% endfor %}
                 </section>
                 <section class="failures">
-                    {% for fname, exception, description, hasMore, file, line, column, snippet in failures %}
-						<fieldset class="failure">
-							<h2>EXCEPTION in {{fname}}: {{exception}}</h2>
-							{% if hasMore %}
-								<p>{{description}} in {{file}} on line {{line}}, column {{column}}:</p>
-								<p>{{snippet}}</p>
-                        	{% else %}
-								<p>{{description}}</p>
-							{% endif %}
-						</fieldset>
+                    {% for name, traceback in failures %}
+                        <fieldset class="failure">
+                            <h2>EXCEPTION in {{name}}</h2>
+                            <pre>
+{{traceback}}
+                            </pre>
+                        </fieldset>
                     {% endfor %}
                 </section>
             </div>
@@ -38,3 +35,4 @@
         </div>
     </body>
 </body>
+    

--- a/workbench/views.py
+++ b/workbench/views.py
@@ -42,22 +42,8 @@ def index(_request):
     for failure in FAILURES:
         failures.append([
             failure["name"],
-            type(failure["exception"]).__name__,
+            failure["tb"].replace("<", "&lt;").replace(">", "&gt;")
         ])
-        try:
-            failures[-1].extend([failure["exception"].args[0]])
-        except:
-            failures[-1].extend([None])
-        try:
-            failures[-1].extend([
-                True,
-                failure["exception"].args[1][0],
-                failure["exception"].args[1][1],
-                failure["exception"].args[1][2],
-                failure["exception"].args[1][3]
-            ])
-        except:
-            failures[-1].extend([False, None, None, None, None])
     return render_to_response('workbench/index.html', {
         'scenarios': [(desc, scenario.description) for desc, scenario in the_scenarios],
         'failures': failures


### PR DESCRIPTION
Previously, XBlocks that failed to load simply wouldn't appear on the workbench. Now, failed XBlocks, if present, have a traceback that can be seen on the workbench index. @pmitros @nedbat 

**Note**: This relies on XBlock pull request [240](https://github.com/edx/XBlock/pull/240), so this should be merged after that request gets merged onto master. Thus, the Travis CI build will fail until then.
