### PR TITLE
Update cookiecutter to 0.8.0.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-cookiecutter==0.7.1
+cookiecutter==0.8.0
 Django >= 1.4, < 1.5
 lxml
 requests


### PR DESCRIPTION
I keep getting the following error when trying to install version 0.7.1:

```
Exception:
Traceback (most recent call last):
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/pip/basecommand.py", line 122, in main
    status = self.run(options, args)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/pip/commands/install.py", line 278, in run
    requirement_set.prepare_files(finder, force_root_egg_info=self.bundle, bundle=self.bundle)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/pip/req.py", line 1197, in prepare_files
    do_download,
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/pip/req.py", line 1375, in unpack_url
    self.session,
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/pip/download.py", line 582, in unpack_http_url
    unpack_file(temp_location, location, content_type, link)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/pip/util.py", line 625, in unpack_file
    untar_file(filename, location)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/pip/util.py", line 556, in untar_file
    path = os.path.join(location, fn)
  File "/edx/app/edxapp/venvs/edxapp/lib/python2.7/posixpath.py", line 71, in join
    path += '/' + b
UnicodeDecodeError: 'ascii' codec can't decode byte 0xcc in position 16: ordinal not in range(128)
```
