### PR TITLE
Bump version for the release

### DIFF
--- a/workbench/__init__.py
+++ b/workbench/__init__.py
@@ -2,4 +2,4 @@
 Provide a djangoapp for XBlock development
 """
 
-__version__ = '0.4.0'
+__version__ = '0.5.1'


### PR DESCRIPTION
This PR bumps the version in the init file for the next release. As a part of the cleanup effort, a new version is needed after the [PR](https://github.com/openedx/xblock-sdk/pull/216) so it is a follow up to that PR and corrects the version issue.