### PR TITLE
fix: Install pip and pip-tools in upgrade script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,8 @@ upgrade: $(COMMON_CONSTRAINTS_TXT)	## update the requirements/*.txt files with t
 	# Make sure to compile files after any other files they include!
 	pip-compile --upgrade --allow-unsafe --rebuild -o requirements/pip.txt requirements/pip.in
 	pip-compile --upgrade -o requirements/pip-tools.txt requirements/pip-tools.in
+	pip install -qr requirements/pip.txt
+	pip install -qr requirements/pip-tools.txt
 	pip-compile --rebuild --upgrade -o requirements/base.txt requirements/base.in
 	pip-compile --rebuild --upgrade -o requirements/test.txt requirements/test.in
 	pip-compile --rebuild --upgrade -o requirements/quality.txt requirements/quality.in

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,38 +6,38 @@
 #
 appdirs==1.4.4
     # via fs
-arrow==1.2.1
+arrow==1.2.2
     # via jinja2-time
-asgiref==3.5.0
+asgiref==3.5.2
     # via django
 binaryornot==0.4.4
     # via cookiecutter
 boto==2.49.0
     # via -r requirements/base.in
-boto3==1.20.41
+boto3==1.24.3
     # via fs-s3fs
-botocore==1.23.41
+botocore==1.27.3
     # via
     #   boto3
     #   s3transfer
-certifi==2021.10.8
+certifi==2022.5.18.1
     # via requests
 chardet==4.0.0
     # via binaryornot
-charset-normalizer==2.0.10
+charset-normalizer==2.0.12
     # via requests
-click==8.0.3
+click==8.1.3
     # via cookiecutter
-cookiecutter==1.7.3
+cookiecutter==2.1.1
     # via -r requirements/base.in
-django==3.2.11
+django==3.2.13
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/base.in
     #   django-pyfs
 django-pyfs==3.2.0
     # via -r requirements/base.in
-fs==2.4.14
+fs==2.4.16
     # via
     #   django-pyfs
     #   fs-s3fs
@@ -48,28 +48,26 @@ fs-s3fs==1.1.1
     #   django-pyfs
 idna==3.3
     # via requests
-jinja2==3.0.3
+jinja2==3.1.2
     # via
     #   cookiecutter
     #   jinja2-time
 jinja2-time==0.2.0
     # via cookiecutter
-jmespath==0.10.0
+jmespath==1.0.0
     # via
     #   boto3
     #   botocore
 lazy==1.4
     # via -r requirements/base.in
-lxml==4.7.1
+lxml==4.9.0
     # via
     #   -r requirements/base.in
     #   xblock
-markupsafe==2.0.1
+markupsafe==2.1.1
     # via
     #   jinja2
     #   xblock
-poyo==0.5.0
-    # via cookiecutter
 pypng==0.0.21
     # via -r requirements/base.in
 python-dateutil==2.8.2
@@ -77,26 +75,26 @@ python-dateutil==2.8.2
     #   arrow
     #   botocore
     #   xblock
-python-slugify==5.0.2
+python-slugify==6.1.2
     # via cookiecutter
-pytz==2021.3
+pytz==2022.1
     # via
     #   django
-    #   fs
     #   xblock
 pyyaml==6.0
-    # via xblock
+    # via
+    #   cookiecutter
+    #   xblock
 requests==2.27.1
     # via
     #   -r requirements/base.in
     #   cookiecutter
-s3transfer==0.5.0
+s3transfer==0.6.0
     # via boto3
 simplejson==3.17.6
     # via -r requirements/base.in
 six==1.16.0
     # via
-    #   cookiecutter
     #   fs
     #   fs-s3fs
     #   python-dateutil
@@ -104,7 +102,7 @@ sqlparse==0.4.2
     # via django
 text-unidecode==1.3
     # via python-slugify
-urllib3==1.26.8
+urllib3==1.26.9
     # via
     #   botocore
     #   requests
@@ -116,7 +114,7 @@ webob==1.8.7
     # via
     #   -r requirements/base.in
     #   xblock
-xblock==1.5.1
+xblock==1.6.1
     # via -r requirements/base.in
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,17 +4,17 @@
 #
 #    make upgrade
 #
-certifi==2021.10.8
+certifi==2022.5.18.1
     # via requests
-charset-normalizer==2.0.10
+charset-normalizer==2.0.12
     # via requests
 codecov==2.1.12
     # via -r requirements/ci.in
-coverage==6.2
+coverage==6.4.1
     # via codecov
 distlib==0.3.4
     # via virtualenv
-filelock==3.4.2
+filelock==3.7.1
     # via
     #   tox
     #   virtualenv
@@ -22,13 +22,13 @@ idna==3.3
     # via requests
 packaging==21.3
     # via tox
-platformdirs==2.4.1
+platformdirs==2.5.2
     # via virtualenv
 pluggy==1.0.0
     # via tox
 py==1.11.0
     # via tox
-pyparsing==3.0.7
+pyparsing==3.0.9
     # via packaging
 requests==2.27.1
     # via codecov
@@ -38,13 +38,13 @@ six==1.16.0
     #   virtualenv
 toml==0.10.2
     # via tox
-tox==3.24.5
+tox==3.25.0
     # via
     #   -r requirements/ci.in
     #   tox-battery
 tox-battery==0.6.1
     # via -r requirements/ci.in
-urllib3==1.26.8
+urllib3==1.26.9
     # via requests
-virtualenv==20.13.0
+virtualenv==20.14.1
     # via tox

--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -15,10 +15,11 @@
 # using LTS django version
 Django<4.0
 
-# latest version is causing e2e failures in edx-platform.
-# See pyjwt[crypto]<2.0.0 comment.
-drf-jwt<1.19.1
-
 # elasticsearch>=7.14.0 includes breaking changes in it which caused issues in discovery upgrade process.
 # elastic search changelog: https://www.elastic.co/guide/en/enterprise-search/master/release-notes-7.14.0.html
 elasticsearch<7.14.0
+
+setuptools<60
+
+# django-simple-history>3.0.0 adds indexing and causes a lot of migrations to be affected
+django-simple-history==3.0.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -13,17 +13,17 @@ appdirs==1.4.4
     #   -r requirements/base.txt
     #   -r requirements/test.txt
     #   fs
-arrow==1.2.1
+arrow==1.2.2
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.txt
     #   jinja2-time
-asgiref==3.5.0
+asgiref==3.5.2
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.txt
     #   django
-astroid==2.9.3
+astroid==2.11.5
     # via
     #   pylint
     #   pylint-celery
@@ -36,7 +36,7 @@ binaryornot==0.4.4
     #   -r requirements/base.txt
     #   -r requirements/test.txt
     #   cookiecutter
-bok_choy==0.7.1
+bok-choy==0.7.1
     # via
     #   -r requirements/test.in
     #   -r requirements/test.txt
@@ -44,18 +44,18 @@ boto==2.49.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.txt
-boto3==1.20.41
+boto3==1.24.3
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.txt
     #   fs-s3fs
-botocore==1.23.41
+botocore==1.27.3
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.txt
     #   boto3
     #   s3transfer
-certifi==2021.10.8
+certifi==2022.5.18.1
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.txt
@@ -65,12 +65,12 @@ chardet==4.0.0
     #   -r requirements/base.txt
     #   -r requirements/test.txt
     #   binaryornot
-charset-normalizer==2.0.10
+charset-normalizer==2.0.12
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.txt
     #   requests
-click==8.0.3
+click==8.1.3
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.txt
@@ -78,28 +78,30 @@ click==8.0.3
     #   code-annotations
     #   cookiecutter
     #   edx-lint
-click-log==0.3.2
+click-log==0.4.0
     # via edx-lint
-code-annotations==1.2.0
+code-annotations==1.3.0
     # via edx-lint
-cookiecutter==1.7.3
+cookiecutter==2.1.1
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.txt
-coverage[toml]==6.2
+coverage[toml]==6.4.1
     # via
     #   -r requirements/test.in
     #   -r requirements/test.txt
     #   pytest-cov
-ddt==1.4.4
+ddt==1.5.0
     # via
     #   -r requirements/test.in
     #   -r requirements/test.txt
+dill==0.3.5.1
+    # via pylint
 distlib==0.3.4
     # via
     #   -r requirements/test.txt
     #   virtualenv
-django==3.2.11
+django==3.2.13
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/base.txt
@@ -109,14 +111,14 @@ django-pyfs==3.2.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.txt
-edx-lint==5.2.1
+edx-lint==5.2.2
     # via -r requirements/quality.in
-filelock==3.4.2
+filelock==3.7.1
     # via
     #   -r requirements/test.txt
     #   tox
     #   virtualenv
-fs==2.4.14
+fs==2.4.16
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.txt
@@ -141,7 +143,7 @@ isort==5.10.1
     # via
     #   -r requirements/quality.in
     #   pylint
-jinja2==3.0.3
+jinja2==3.1.2
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.txt
@@ -153,7 +155,7 @@ jinja2-time==0.2.0
     #   -r requirements/base.txt
     #   -r requirements/test.txt
     #   cookiecutter
-jmespath==0.10.0
+jmespath==1.0.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.txt
@@ -167,23 +169,23 @@ lazy==1.4
     #   bok-choy
 lazy-object-proxy==1.7.1
     # via astroid
-lxml==4.7.1
+lxml==4.9.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.txt
     #   xblock
-mako==1.1.6
+mako==1.2.0
     # via
     #   -r requirements/test.txt
     #   acid-xblock
-markupsafe==2.0.1
+markupsafe==2.1.1
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.txt
     #   jinja2
     #   mako
     #   xblock
-mccabe==0.6.1
+mccabe==0.7.0
     # via pylint
 mock==4.0.3
     # via
@@ -202,13 +204,13 @@ packaging==21.3
     #   -r requirements/test.txt
     #   pytest
     #   tox
-pbr==5.8.0
+pbr==5.9.0
     # via stevedore
-pillow==9.0.0
+pillow==9.1.1
     # via
     #   -r requirements/test.txt
     #   needle
-platformdirs==2.4.1
+platformdirs==2.5.2
     # via
     #   -r requirements/test.txt
     #   pylint
@@ -218,11 +220,6 @@ pluggy==1.0.0
     #   -r requirements/test.txt
     #   pytest
     #   tox
-poyo==0.5.0
-    # via
-    #   -r requirements/base.txt
-    #   -r requirements/test.txt
-    #   cookiecutter
 py==1.11.0
     # via
     #   -r requirements/test.txt
@@ -232,7 +229,7 @@ pycodestyle==2.8.0
     # via -r requirements/quality.in
 pydocstyle==6.1.1
     # via -r requirements/quality.in
-pylint==2.12.2
+pylint==2.14.1
     # via
     #   edx-lint
     #   pylint-celery
@@ -240,13 +237,13 @@ pylint==2.12.2
     #   pylint-plugin-utils
 pylint-celery==0.3
     # via edx-lint
-pylint-django==2.5.0
+pylint-django==2.5.3
     # via edx-lint
 pylint-plugin-utils==0.7
     # via
     #   pylint-celery
     #   pylint-django
-pyparsing==3.0.7
+pyparsing==3.0.9
     # via
     #   -r requirements/test.txt
     #   packaging
@@ -254,7 +251,7 @@ pypng==0.0.21
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.txt
-pytest==6.2.5
+pytest==7.1.2
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -279,31 +276,31 @@ python-dateutil==2.8.2
     #   arrow
     #   botocore
     #   xblock
-python-slugify==5.0.2
+python-slugify==6.1.2
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.txt
     #   code-annotations
     #   cookiecutter
-pytz==2021.3
+pytz==2022.1
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.txt
     #   django
-    #   fs
     #   xblock
 pyyaml==6.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.txt
     #   code-annotations
+    #   cookiecutter
     #   xblock
 requests==2.27.1
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.txt
     #   cookiecutter
-s3transfer==0.5.0
+s3transfer==0.6.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.txt
@@ -323,7 +320,6 @@ six==1.16.0
     #   -r requirements/base.txt
     #   -r requirements/test.txt
     #   bok-choy
-    #   cookiecutter
     #   edx-lint
     #   fs
     #   fs-s3fs
@@ -347,14 +343,16 @@ text-unidecode==1.3
 toml==0.10.2
     # via
     #   -r requirements/test.txt
-    #   pylint
-    #   pytest
     #   tox
-tomli==2.0.0
+tomli==2.0.1
     # via
     #   -r requirements/test.txt
     #   coverage
-tox==3.24.5
+    #   pylint
+    #   pytest
+tomlkit==0.11.0
+    # via pylint
+tox==3.25.0
     # via
     #   -r requirements/test.in
     #   -r requirements/test.txt
@@ -363,17 +361,17 @@ tox-battery==0.6.1
     # via
     #   -r requirements/test.in
     #   -r requirements/test.txt
-typing-extensions==4.0.1
+typing-extensions==4.2.0
     # via
     #   astroid
     #   pylint
-urllib3==1.26.8
+urllib3==1.26.9
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.txt
     #   botocore
     #   requests
-virtualenv==20.13.0
+virtualenv==20.14.1
     # via
     #   -r requirements/test.txt
     #   tox
@@ -387,9 +385,9 @@ webob==1.8.7
     #   -r requirements/base.txt
     #   -r requirements/test.txt
     #   xblock
-wrapt==1.13.3
+wrapt==1.14.1
     # via astroid
-xblock==1.5.1
+xblock==1.6.1
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.txt

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,13 +4,13 @@
 #
 #    make upgrade
 #
-click==8.0.3
+click==8.1.3
     # via pip-tools
 pep517==0.12.0
     # via pip-tools
-pip-tools==6.6.1
+pip-tools==6.6.2
     # via -r requirements/pip-tools.in
-tomli==2.0.0
+tomli==2.0.1
     # via pep517
 wheel==0.37.1
     # via pip-tools

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -8,7 +8,7 @@ wheel==0.37.1
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==21.3.1
+pip==22.1.2
     # via -r requirements/pip.in
-setuptools==60.5.0
+setuptools==62.3.2
     # via -r requirements/pip.in

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -10,15 +10,15 @@ appdirs==1.4.4
     # via
     #   -r requirements/test.txt
     #   fs
-arrow==1.2.1
+arrow==1.2.2
     # via
     #   -r requirements/test.txt
     #   jinja2-time
-asgiref==3.5.0
+asgiref==3.5.2
     # via
     #   -r requirements/test.txt
     #   django
-astroid==2.9.3
+astroid==2.11.5
     # via
     #   pylint
     #   pylint-celery
@@ -30,20 +30,20 @@ binaryornot==0.4.4
     # via
     #   -r requirements/test.txt
     #   cookiecutter
-bok_choy==0.7.1
+bok-choy==0.7.1
     # via -r requirements/test.txt
 boto==2.49.0
     # via -r requirements/test.txt
-boto3==1.20.41
+boto3==1.24.3
     # via
     #   -r requirements/test.txt
     #   fs-s3fs
-botocore==1.23.41
+botocore==1.27.3
     # via
     #   -r requirements/test.txt
     #   boto3
     #   s3transfer
-certifi==2021.10.8
+certifi==2022.5.18.1
     # via
     #   -r requirements/test.txt
     #   requests
@@ -51,48 +51,50 @@ chardet==4.0.0
     # via
     #   -r requirements/test.txt
     #   binaryornot
-charset-normalizer==2.0.10
+charset-normalizer==2.0.12
     # via
     #   -r requirements/test.txt
     #   requests
-click==8.0.3
+click==8.1.3
     # via
     #   -r requirements/test.txt
     #   click-log
     #   code-annotations
     #   cookiecutter
     #   edx-lint
-click-log==0.3.2
+click-log==0.4.0
     # via edx-lint
-code-annotations==1.2.0
+code-annotations==1.3.0
     # via edx-lint
-cookiecutter==1.7.3
+cookiecutter==2.1.1
     # via -r requirements/test.txt
-coverage[toml]==6.2
+coverage[toml]==6.4.1
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-ddt==1.4.4
+ddt==1.5.0
     # via -r requirements/test.txt
+dill==0.3.5.1
+    # via pylint
 distlib==0.3.4
     # via
     #   -r requirements/test.txt
     #   virtualenv
-django==3.2.11
+django==3.2.13
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/test.txt
     #   django-pyfs
 django-pyfs==3.2.0
     # via -r requirements/test.txt
-edx-lint==5.2.1
+edx-lint==5.2.2
     # via -r requirements/quality.in
-filelock==3.4.2
+filelock==3.7.1
     # via
     #   -r requirements/test.txt
     #   tox
     #   virtualenv
-fs==2.4.14
+fs==2.4.16
     # via
     #   -r requirements/test.txt
     #   django-pyfs
@@ -114,7 +116,7 @@ isort==5.10.1
     # via
     #   -r requirements/quality.in
     #   pylint
-jinja2==3.0.3
+jinja2==3.1.2
     # via
     #   -r requirements/test.txt
     #   code-annotations
@@ -124,7 +126,7 @@ jinja2-time==0.2.0
     # via
     #   -r requirements/test.txt
     #   cookiecutter
-jmespath==0.10.0
+jmespath==1.0.0
     # via
     #   -r requirements/test.txt
     #   boto3
@@ -136,21 +138,21 @@ lazy==1.4
     #   bok-choy
 lazy-object-proxy==1.7.1
     # via astroid
-lxml==4.7.1
+lxml==4.9.0
     # via
     #   -r requirements/test.txt
     #   xblock
-mako==1.1.6
+mako==1.2.0
     # via
     #   -r requirements/test.txt
     #   acid-xblock
-markupsafe==2.0.1
+markupsafe==2.1.1
     # via
     #   -r requirements/test.txt
     #   jinja2
     #   mako
     #   xblock
-mccabe==0.6.1
+mccabe==0.7.0
     # via pylint
 mock==4.0.3
     # via -r requirements/test.txt
@@ -167,13 +169,13 @@ packaging==21.3
     #   -r requirements/test.txt
     #   pytest
     #   tox
-pbr==5.8.0
+pbr==5.9.0
     # via stevedore
-pillow==9.0.0
+pillow==9.1.1
     # via
     #   -r requirements/test.txt
     #   needle
-platformdirs==2.4.1
+platformdirs==2.5.2
     # via
     #   -r requirements/test.txt
     #   pylint
@@ -183,10 +185,6 @@ pluggy==1.0.0
     #   -r requirements/test.txt
     #   pytest
     #   tox
-poyo==0.5.0
-    # via
-    #   -r requirements/test.txt
-    #   cookiecutter
 py==1.11.0
     # via
     #   -r requirements/test.txt
@@ -196,7 +194,7 @@ pycodestyle==2.8.0
     # via -r requirements/quality.in
 pydocstyle==6.1.1
     # via -r requirements/quality.in
-pylint==2.12.2
+pylint==2.14.1
     # via
     #   edx-lint
     #   pylint-celery
@@ -204,19 +202,19 @@ pylint==2.12.2
     #   pylint-plugin-utils
 pylint-celery==0.3
     # via edx-lint
-pylint-django==2.5.0
+pylint-django==2.5.3
     # via edx-lint
 pylint-plugin-utils==0.7
     # via
     #   pylint-celery
     #   pylint-django
-pyparsing==3.0.7
+pyparsing==3.0.9
     # via
     #   -r requirements/test.txt
     #   packaging
 pypng==0.0.21
     # via -r requirements/test.txt
-pytest==6.2.5
+pytest==7.1.2
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -234,27 +232,27 @@ python-dateutil==2.8.2
     #   arrow
     #   botocore
     #   xblock
-python-slugify==5.0.2
+python-slugify==6.1.2
     # via
     #   -r requirements/test.txt
     #   code-annotations
     #   cookiecutter
-pytz==2021.3
+pytz==2022.1
     # via
     #   -r requirements/test.txt
     #   django
-    #   fs
     #   xblock
 pyyaml==6.0
     # via
     #   -r requirements/test.txt
     #   code-annotations
+    #   cookiecutter
     #   xblock
 requests==2.27.1
     # via
     #   -r requirements/test.txt
     #   cookiecutter
-s3transfer==0.5.0
+s3transfer==0.6.0
     # via
     #   -r requirements/test.txt
     #   boto3
@@ -269,7 +267,6 @@ six==1.16.0
     # via
     #   -r requirements/test.txt
     #   bok-choy
-    #   cookiecutter
     #   edx-lint
     #   fs
     #   fs-s3fs
@@ -291,29 +288,31 @@ text-unidecode==1.3
 toml==0.10.2
     # via
     #   -r requirements/test.txt
-    #   pylint
-    #   pytest
     #   tox
-tomli==2.0.0
+tomli==2.0.1
     # via
     #   -r requirements/test.txt
     #   coverage
-tox==3.24.5
+    #   pylint
+    #   pytest
+tomlkit==0.11.0
+    # via pylint
+tox==3.25.0
     # via
     #   -r requirements/test.txt
     #   tox-battery
 tox-battery==0.6.1
     # via -r requirements/test.txt
-typing-extensions==4.0.1
+typing-extensions==4.2.0
     # via
     #   astroid
     #   pylint
-urllib3==1.26.8
+urllib3==1.26.9
     # via
     #   -r requirements/test.txt
     #   botocore
     #   requests
-virtualenv==20.13.0
+virtualenv==20.14.1
     # via
     #   -r requirements/test.txt
     #   tox
@@ -325,9 +324,9 @@ webob==1.8.7
     # via
     #   -r requirements/test.txt
     #   xblock
-wrapt==1.13.3
+wrapt==1.14.1
     # via astroid
-xblock==1.5.1
+xblock==1.6.1
     # via
     #   -r requirements/test.txt
     #   acid-xblock

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -10,11 +10,11 @@ appdirs==1.4.4
     # via
     #   -r requirements/base.txt
     #   fs
-arrow==1.2.1
+arrow==1.2.2
     # via
     #   -r requirements/base.txt
     #   jinja2-time
-asgiref==3.5.0
+asgiref==3.5.2
     # via
     #   -r requirements/base.txt
     #   django
@@ -24,20 +24,20 @@ binaryornot==0.4.4
     # via
     #   -r requirements/base.txt
     #   cookiecutter
-bok_choy==0.7.1
+bok-choy==0.7.1
     # via -r requirements/test.in
 boto==2.49.0
     # via -r requirements/base.txt
-boto3==1.20.41
+boto3==1.24.3
     # via
     #   -r requirements/base.txt
     #   fs-s3fs
-botocore==1.23.41
+botocore==1.27.3
     # via
     #   -r requirements/base.txt
     #   boto3
     #   s3transfer
-certifi==2021.10.8
+certifi==2022.5.18.1
     # via
     #   -r requirements/base.txt
     #   requests
@@ -45,21 +45,21 @@ chardet==4.0.0
     # via
     #   -r requirements/base.txt
     #   binaryornot
-charset-normalizer==2.0.10
+charset-normalizer==2.0.12
     # via
     #   -r requirements/base.txt
     #   requests
-click==8.0.3
+click==8.1.3
     # via
     #   -r requirements/base.txt
     #   cookiecutter
-cookiecutter==1.7.3
+cookiecutter==2.1.1
     # via -r requirements/base.txt
-coverage[toml]==6.2
+coverage[toml]==6.4.1
     # via
     #   -r requirements/test.in
     #   pytest-cov
-ddt==1.4.4
+ddt==1.5.0
     # via -r requirements/test.in
 distlib==0.3.4
     # via virtualenv
@@ -69,11 +69,11 @@ distlib==0.3.4
     #   django-pyfs
 django-pyfs==3.2.0
     # via -r requirements/base.txt
-filelock==3.4.2
+filelock==3.7.1
     # via
     #   tox
     #   virtualenv
-fs==2.4.14
+fs==2.4.16
     # via
     #   -r requirements/base.txt
     #   django-pyfs
@@ -89,7 +89,7 @@ idna==3.3
     #   requests
 iniconfig==1.1.1
     # via pytest
-jinja2==3.0.3
+jinja2==3.1.2
     # via
     #   -r requirements/base.txt
     #   cookiecutter
@@ -98,7 +98,7 @@ jinja2-time==0.2.0
     # via
     #   -r requirements/base.txt
     #   cookiecutter
-jmespath==0.10.0
+jmespath==1.0.0
     # via
     #   -r requirements/base.txt
     #   boto3
@@ -108,13 +108,13 @@ lazy==1.4
     #   -r requirements/base.txt
     #   acid-xblock
     #   bok-choy
-lxml==4.7.1
+lxml==4.9.0
     # via
     #   -r requirements/base.txt
     #   xblock
-mako==1.1.6
+mako==1.2.0
     # via acid-xblock
-markupsafe==2.0.1
+markupsafe==2.1.1
     # via
     #   -r requirements/base.txt
     #   jinja2
@@ -130,27 +130,23 @@ packaging==21.3
     # via
     #   pytest
     #   tox
-pillow==9.0.0
+pillow==9.1.1
     # via needle
-platformdirs==2.4.1
+platformdirs==2.5.2
     # via virtualenv
 pluggy==1.0.0
     # via
     #   pytest
     #   tox
-poyo==0.5.0
-    # via
-    #   -r requirements/base.txt
-    #   cookiecutter
 py==1.11.0
     # via
     #   pytest
     #   tox
-pyparsing==3.0.7
+pyparsing==3.0.9
     # via packaging
 pypng==0.0.21
     # via -r requirements/base.txt
-pytest==6.2.5
+pytest==7.1.2
     # via
     #   pytest-cov
     #   pytest-django
@@ -167,25 +163,25 @@ python-dateutil==2.8.2
     #   arrow
     #   botocore
     #   xblock
-python-slugify==5.0.2
+python-slugify==6.1.2
     # via
     #   -r requirements/base.txt
     #   cookiecutter
-pytz==2021.3
+pytz==2022.1
     # via
     #   -r requirements/base.txt
     #   django
-    #   fs
     #   xblock
 pyyaml==6.0
     # via
     #   -r requirements/base.txt
+    #   cookiecutter
     #   xblock
 requests==2.27.1
     # via
     #   -r requirements/base.txt
     #   cookiecutter
-s3transfer==0.5.0
+s3transfer==0.6.0
     # via
     #   -r requirements/base.txt
     #   boto3
@@ -200,7 +196,6 @@ six==1.16.0
     # via
     #   -r requirements/base.txt
     #   bok-choy
-    #   cookiecutter
     #   fs
     #   fs-s3fs
     #   python-dateutil
@@ -215,23 +210,23 @@ text-unidecode==1.3
     #   -r requirements/base.txt
     #   python-slugify
 toml==0.10.2
+    # via tox
+tomli==2.0.1
     # via
+    #   coverage
     #   pytest
-    #   tox
-tomli==2.0.0
-    # via coverage
-tox==3.24.5
+tox==3.25.0
     # via
     #   -r requirements/test.in
     #   tox-battery
 tox-battery==0.6.1
     # via -r requirements/test.in
-urllib3==1.26.8
+urllib3==1.26.9
     # via
     #   -r requirements/base.txt
     #   botocore
     #   requests
-virtualenv==20.13.0
+virtualenv==20.14.1
     # via tox
 web-fragments==2.0.0
     # via
@@ -241,7 +236,7 @@ webob==1.8.7
     # via
     #   -r requirements/base.txt
     #   xblock
-xblock==1.5.1
+xblock==1.6.1
     # via
     #   -r requirements/base.txt
     #   acid-xblock


### PR DESCRIPTION
Updated the upgrade target script to check the compatibility of upgraded pip and pip-tools versions.
For reference, look at this [PR](https://github.com/openedx/edx-repo-health/pull/271) for new check added in edx-repo-health. 
JIRA: https://2u-internal.atlassian.net/browse/BOM-3448