### PR TITLE
fix: not found error while loading file from media storage

### DIFF
--- a/workbench/urls.py
+++ b/workbench/urls.py
@@ -1,10 +1,11 @@
 """Provide XBlock urls"""
 
 
-
-from django.urls import re_path
+from django.conf import settings
+from django.conf.urls.static import static
 from django.contrib import admin
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
+from django.urls import re_path
 
 from workbench import views
 
@@ -65,3 +66,5 @@ urlpatterns = [
 ]
 
 urlpatterns += staticfiles_urlpatterns()
+
+urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION
In cases where a xblock uploads files in media storage workbench is unable to load those files and throws 404 since media file handling url pattern is not set in url configuration. 
This PR add media file handler in url configuration as suggested in [django docs](https://docs.djangoproject.com/en/4.1/howto/static-files/#serving-files-uploaded-by-a-user-during-development).