### PR TITLE
chore: python upgrade now clones testeng-ci from its actual github lo…

### DIFF
--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: setup testeng-ci
         run: |
-          git clone https://github.com/openedx/testeng-ci.git
+          git clone https://github.com/edx/testeng-ci.git
           cd $GITHUB_WORKSPACE/testeng-ci
           pip install -r requirements/base.txt
       - name: create pull request


### PR DESCRIPTION
This is in response to a [github alert](https://github.com/openedx/xblock-sdk/actions/runs/3262340769) to the effect that the weekly python upgrade job for this repo was failing.

Learned from Jeremy Bowman that this error is an instance of a handful of repos that had their python upgrade scripts corrupted by an automated URL update job. This is a one-line fix to restore the reference to the `testeng-ci` dependency to its correct home (edx, not openedx).
