### PR TITLE
chore: TNL-10182 testeng-ci from edx

### DIFF
--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v1
         with:
           ref: ${{ env.target_branch }}
-      
+
       - name: setup python
         uses: actions/setup-python@v2
         with:
@@ -39,7 +39,7 @@ jobs:
 
       - name: setup testeng-ci
         run: |
-          git clone https://github.com/openedx/testeng-ci.git
+          git clone https://github.com/edx/testeng-ci.git
           cd $GITHUB_WORKSPACE/testeng-ci
           pip install -r requirements/base.txt
       - name: create pull request


### PR DESCRIPTION
Fix source repo for testeng-ci dependency to edx (from improperly set openedx), per https://2u-internal.app.opsgenie.com/alert/detail/cbeddbaf-a87a-4fd0-9f01-929c73aa7522-1666585204769/details. The dependency was apparently set to the incorrect openedx home by an automated URL replacement script in the recent past.

