### PR TITLE
Drop py3.8 support | Replace pkg_resources lib with importlib.resources

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04]
-        python-version: ['3.8', '3.11', '3.12']
+        python-version: ['3.11', '3.12']
         toxenv: [django42]
     steps:
     - uses: actions/checkout@v2
@@ -31,7 +31,7 @@ jobs:
       run:  tox -e ${{ matrix.toxenv }}
 
     - name: Upload coverage to CodeCov
-      if: matrix.python-version == '3.8' && matrix.toxenv == 'django42'
+      if: matrix.python-version == '3.11' && matrix.toxenv == 'django42'
       uses: codecov/codecov-action@v4
       with:
         file: ./coverage.xml

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -16,7 +16,7 @@ jobs:
       - name: setup python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.11
 
       - name: Install pip
         run: pip install -r requirements/pip.txt

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,11 @@ Change history for XBlock SDK
 
 These are notable changes in XBlock.
 
+1.0.0 - 2024-05-30
+------------------
+* dropped python 3.8 support
+* transitioned from deprecated pkg_resources lib to importlib.resources
+
 0.9.0
 -----
 * Xblock bumped to 3.0.0. Removed the deprecated id_generator method parameter in xblock.runtime

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY . /usr/local/src/xblock-sdk
 WORKDIR /usr/local/src/xblock-sdk
 
 ENV VIRTUAL_ENV=/venvs/xblock-sdk
-RUN python3.8 -m venv $VIRTUAL_ENV
+RUN python3.11 -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
 RUN pip install --upgrade pip && pip install -r /usr/local/src/xblock-sdk/requirements/dev.txt

--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ Getting Started
 Developing
 ==========
 
-This code runs on Python 3.8 or newer.
+This code runs on Python 3.11 or newer.
 
 One Time Setup
 --------------
@@ -40,7 +40,7 @@ One Time Setup
 
   # Set up a virtualenv with the same name as the repo and activate it
   # Here's how you might do that if you have virtualenvwrapper setup.
-  mkvirtualenv -p python3.8 xblock-sdk
+  mkvirtualenv -p python3.11 xblock-sdk
 
   # Install system requirements needed to run this on ubuntu.
   # Note: Debian 10 needs libjpeg62-turbo-dev instead of libjpeg62-dev.
@@ -107,7 +107,7 @@ On the first startup run the following command to create the SQLite database.
 
 Command::
 
-    $ docker container exec -it edx.devstack.xblock-sdk python3.8 manage.py migrate
+    $ docker container exec -it edx.devstack.xblock-sdk python3.11 manage.py migrate
 
 You should now be able to access the XBlock SDK environment in your browser at http://localhost:8000
 

--- a/sample_xblocks/filethumbs/filethumbs.py
+++ b/sample_xblocks/filethumbs/filethumbs.py
@@ -17,12 +17,10 @@ thumbs block will be instructive.
 
 """
 
-
-
 import json
 import logging
 
-import pkg_resources
+import importlib.resources
 import png
 from web_fragments.fragment import Fragment
 from xblock.core import XBlock
@@ -72,8 +70,9 @@ class FileThumbsBlock(XBlock):
         """
 
         # Load the HTML fragment from within the package and fill in the template
-        html_str = pkg_resources.resource_string(__name__,
-                                                 "static/html/thumbs.html").decode('utf-8')
+        html_str = importlib.resources.files(__package__).joinpath(
+            "static/html/thumbs.html"
+        ).read_text(encoding="utf-8")
         frag = Fragment(str(html_str))
 
         if not self.fs.exists("thumbsvotes.json"):
@@ -86,12 +85,10 @@ class FileThumbsBlock(XBlock):
         self.downvotes = votes['down']
 
         # Load the CSS and JavaScript fragments from within the package
-        css_str = pkg_resources.resource_string(__name__,
-                                                "static/css/thumbs.css").decode('utf-8')
+        css_str = importlib.resources.files(__package__).joinpath("static/css/thumbs.css").read_text(encoding="utf-8")
         frag.add_css(str(css_str))
 
-        js_str = pkg_resources.resource_string(__name__,
-                                               "static/js/src/thumbs.js").decode('utf-8')
+        js_str = importlib.resources.files(__package__).joinpath("static/js/src/thumbs.js").read_text(encoding="utf-8")
         frag.add_javascript(str(js_str))
 
         with self.fs.open('uparrow.png', 'wb') as file_output:

--- a/sample_xblocks/thumbs/thumbs.py
+++ b/sample_xblocks/thumbs/thumbs.py
@@ -1,10 +1,8 @@
 """An XBlock providing thumbs-up/thumbs-down voting."""
 
-
-
 import logging
 
-import pkg_resources
+import importlib.resources
 from web_fragments.fragment import Fragment
 from xblock.core import XBlock, XBlockAside
 from xblock.fields import Boolean, Integer, Scope
@@ -36,17 +34,16 @@ class ThumbsBlockBase:
         """
 
         # Load the HTML fragment from within the package and fill in the template
-        html_str = pkg_resources.resource_string(__name__,
-                                                 "static/html/thumbs.html").decode('utf-8')
+        html_str = importlib.resources.files(
+            __package__
+        ).joinpath("static/html/thumbs.html").read_text(encoding="utf-8")
         frag = Fragment(str(html_str).format(block=self))
 
         # Load the CSS and JavaScript fragments from within the package
-        css_str = pkg_resources.resource_string(__name__,
-                                                "static/css/thumbs.css").decode('utf-8')
+        css_str = importlib.resources.files(__package__).joinpath("static/css/thumbs.css").read_text(encoding="utf-8")
         frag.add_css(str(css_str))
 
-        js_str = pkg_resources.resource_string(__name__,
-                                               "static/js/src/thumbs.js").decode('utf-8')
+        js_str = importlib.resources.files(__package__).joinpath("static/js/src/thumbs.js").read_text(encoding="utf-8")
         frag.add_javascript(str(js_str))
 
         frag.initialize_js('ThumbsBlock')

--- a/setup.py
+++ b/setup.py
@@ -127,7 +127,6 @@ setup(
         'License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)',
         'Natural Language :: English',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{38,311,312}-django{42},quality
+envlist = py{311,312}-django{42},quality
 
 [pycodestyle]
 exclude = .git,.tox,migrations

--- a/workbench/__init__.py
+++ b/workbench/__init__.py
@@ -2,4 +2,4 @@
 Provide a djangoapp for XBlock development
 """
 
-__version__ = '0.11.0'
+__version__ = '0.12.0'


### PR DESCRIPTION
- Drop Py3.8 support 
- Replace pkg_resources lib with importlib.resources

Ticket: https://github.com/openedx/XBlock/issues/676

PR is expected to merge after Open edX redwood release

Followed migration guide: https://importlib-resources.readthedocs.io/en/latest/migration.html

**Testing:**
I have tested the changes with following steps:
1. Use [PR](https://github.com/openedx/xblock-sdk/pull/350) of `xblock-sdk`
2. Install `xblock` into `xblock-sdk`
3. Install `feedback-xblock` from [PR](https://github.com/openedx/FeedbackXBlock/pull/58) into `xblock-sdk`
4. Test feedback xblock functionality