### PR TITLE
fix: allowed host issue on xblocks

### DIFF
--- a/workbench/settings.py
+++ b/workbench/settings.py
@@ -11,6 +11,9 @@ DJFS = {'type': 'osfs',
         'url_root': '/static/djpyfs'}
 
 DEBUG = True
+
+ALLOWED_HOSTS = ['*']
+
 if os.environ.get('EXCLUDE_SAMPLE_XBLOCKS') == 'yes':
     EXCLUDED_XBLOCKS = {
         'allscopes_demo',


### PR DESCRIPTION
Fixes:

```
DisallowedHost at /
Invalid HTTP_HOST header: '0.0.0.0'. You may need to add '0.0.0.0' to ALLOWED_HOSTS.
```

when working on xblocks.