### PR TITLE
docs: Correct links to the xblock docs.

### DIFF
--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -90,9 +90,9 @@ where you should make changes::
 
 
 For more details about the details of writing an XBlock, please refer to the
-XBlock documentation: https://xblock.readthedocs.org/en/latest/getting_started.html#write-your-xblock
+`XBlock documentation <https://docs.openedx.org/projects/xblock/en/latest/xblock-tutorial/getting_started/index.html>`_
 
-Testing your XBlock in the XBlock-SDK 
+Testing your XBlock in the XBlock-SDK
 --------------------------------------
 
 .. highlight: console
@@ -128,4 +128,4 @@ This will automatically start the workbench on port 8000. If you visit the page:
 
     http://localhost:8000
 
-the workbench should be visible along with the `workbench_scenarios` of any installed XBlocks. 
+the workbench should be visible along with the `workbench_scenarios` of any installed XBlocks.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -8,11 +8,11 @@ XBlock-SDK
     if you have any questions or concerns. Do not make any plans based on this
     document without talking to us first.
 
-This is documentation for using the XBlock-SDK effectively to develop XBlocks. This documentation 
+This is documentation for using the XBlock-SDK effectively to develop XBlocks. This documentation
 does not go into any detail about the inner workings of XBlocks. Please see the primary XBlock documentation
 for any questions and concerns about the XBlock API.
 
-   https://xblock.readthedocs.org/
+   https://docs.openedx.org/projects/xblock/en/latest/
 
 Getting Started
 ---------------


### PR DESCRIPTION
The docs have been moved and re-organized into the main docs site.
