### PR TITLE
chore: remove changelog configuration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           git_committer_name: "github-actions[bot]"
           git_committer_email: "github-actions[bot]@users.noreply.github.com"
-          changelog: "true"
+          changelog: "false"
 
       - name: Upload dist artifacts
         if: steps.release.outputs.released == 'true'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,14 +158,6 @@ uv_constraints = [
     "setuptools<82.0",
 ]
 
-[tool.semantic_release.changelog]
-mode = "update"
-insertion_flag = ".. changelog-insertion-marker"
-
-[tool.semantic_release.changelog.default_templates]
-changelog_file = "CHANGELOG.rst"
-output_format = "rst"
-
 [tool.semantic_release]
 build_command = "python -m pip install --upgrade build && SETUPTOOLS_SCM_PRETEND_VERSION=$NEW_VERSION python -m build"
 allow_zero_version = true


### PR DESCRIPTION
## Summary

- Removes `[tool.semantic_release.changelog]` and `[tool.semantic_release.changelog.default_templates]` sections from `pyproject.toml`
- Sets `changelog: "false"` in `.github/workflows/release.yml`

## Test plan

- [ ] Verify semantic release workflow runs without generating/updating changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)