### PR TITLE
fix: pass github_token to semantic release step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,7 @@ jobs:
         id: release
         uses: python-semantic-release/python-semantic-release@350c48fcb3ffcdfd2e0a235206bc2ecea6b69df0 # v10.5.3
         with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           git_committer_name: "github-actions[bot]"
           git_committer_email: "github-actions[bot]@users.noreply.github.com"
           changelog: "true"


### PR DESCRIPTION
## Summary

- Adds `github_token: ${{ secrets.GITHUB_TOKEN }}` to the Python Semantic Release step in `release.yml`

## Problem

Semantic release was getting a `401 Unauthorized` error when trying to create the GitHub release:

```
401 Client Error: Unauthorized for url: https://api.github.com/repos/openedx/xblock-sdk/releases
Failed to create release on Github!
```

## Cause

The `github_token` input was not passed to the action, so semantic release had no credentials to authenticate against the GitHub API.

## Test plan

- [ ] Verify semantic release workflow completes successfully and creates a GitHub release

🤖 Generated with [Claude Code](https://claude.com/claude-code)