### PR TITLE
fix: add fetch-depth: 0 to release workflow checkout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.ref_name }}
+          fetch-depth: 0
 
       - name: Reset to triggered commit
         run: git reset --hard ${{ github.sha }}


### PR DESCRIPTION
## Summary

- The release workflow checkout was using the default `fetch-depth: 1` (shallow clone), which omits git history and tags.
- PSR needs full history to resolve prior release tags, causing `fatal: Could not parse object` (exit code 128).
- Adds `fetch-depth: 0` to fetch the complete git history.

Fixes: https://github.com/openedx/xblock-sdk/actions/runs/32739600996
Semantic Release Doc: https://python-semantic-release.readthedocs.io/en/stable/configuration/automatic-releases/github-actions.html?utm_source=chatgpt.com

## Test plan

- [ ] Trigger a release workflow run and confirm PSR can resolve prior tags without error.

Note: Generated with [Claude Code](https://claude.com/claude-code) and reviewed by a human.